### PR TITLE
Add basic driver operations: set/get base device name, open and close

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -165,7 +165,7 @@ static struct gendisk *init_disk(sector_t capacity)
 	disk->major = major;
 	disk->first_minor = 0;
 	disk->minors = 1;
-	strcpy(disk->disk_name, base_handle->path);
+	strcpy(disk->disk_name, THIS_DEVICE_NAME);
 	disk->fops = &sdmy_fops;
 	disk->private_data = NULL;
 

--- a/driver.c
+++ b/driver.c
@@ -190,12 +190,14 @@ static const struct block_device_operations sdmy_fops = {
 
 static int close_base(const char *arg, const struct kernel_param *kp)
 {
-	if (!base_handle || !base_handle->bdev_file) {
+	if (!base_handle || !base_handle->bdev_file || !base_handle->assoc_disk) {
 		pr_err("nothing to close\n");
 		return -EINVAL;
 	}
 	fput(base_handle->bdev_file);
+	put_disk(base_handle->assoc_disk);
 	base_handle->bdev_file = NULL;
+	base_handle->assoc_disk = NULL;
 
 	return 0;
 }

--- a/driver.c
+++ b/driver.c
@@ -138,6 +138,7 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 	disk = init_disk(disk_capacity);
 	if (IS_ERR(disk))
 		return PTR_ERR(disk);
+	disk->private_data = base_handle;
 
 	base_handle->bdev_file = bdev_file;
 	base_handle->assoc_disk = disk;
@@ -168,7 +169,6 @@ static struct gendisk *init_disk(sector_t capacity)
 	disk->minors = 1;
 	strcpy(disk->disk_name, THIS_DEVICE_NAME);
 	disk->fops = &sdmy_fops;
-	disk->private_data = NULL;
 
 	err = add_disk(disk);
 	if (err) {

--- a/driver.c
+++ b/driver.c
@@ -9,6 +9,9 @@
 #define THIS_DEVICE_NAME "sdmy"
 #define THIS_DEVICE_PATH "/dev/sdmy"
 
+static struct gendisk *init_disk(sector_t capacity);
+static const struct block_device_operations sdmy_fops;
+
 static struct block_device_handle {
 	struct file *bdev_file;
 	struct gendisk *assoc_disk;
@@ -18,9 +21,6 @@ static struct block_device_handle {
 
 static struct block_device_handle *base_handle;
 static int major;
-
-static struct gendisk *init_disk(sector_t capacity);
-static const struct block_device_operations sdmy_fops;
 
 static int __init blkdevm_init(void)
 {
@@ -36,10 +36,12 @@ static int __init blkdevm_init(void)
 
 static void __exit blkdevm_exit(void)
 {
-	if (base_handle && base_handle->assoc_disk)
-		put_disk(base_handle->assoc_disk);
-	if (base_handle && base_handle->bdev_file)
+	if (base_handle && base_handle->bdev_file) {
 		fput(base_handle->bdev_file);
+	}
+	if (base_handle && base_handle->assoc_disk) {
+		put_disk(base_handle->assoc_disk);
+	}
 	if (base_handle) {
 		kfree(base_handle->name);
 		kfree(base_handle->path);
@@ -137,7 +139,6 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 	if (IS_ERR(disk))
 		return PTR_ERR(disk);
 
-
 	base_handle->bdev_file = bdev_file;
 	base_handle->assoc_disk = disk;
 
@@ -185,7 +186,7 @@ static struct gendisk *init_disk(sector_t capacity)
 
 static const struct block_device_operations sdmy_fops = {
 	.owner = THIS_MODULE,
-//	.submit_bio = sdmy_submit_bio,
+	// .submit_bio = sdmy_submit_bio,
 };
 
 static int close_base(const char *arg, const struct kernel_param *kp)

--- a/driver.c
+++ b/driver.c
@@ -52,14 +52,14 @@ static int base_name_and_path_set(const char *arg, const struct kernel_param *kp
 		pr_err("need to close device before setting new one\n");
 		return -EBUSY;
 	}
-	len = strlen(arg);
 
+	len = strlen(arg);
 	name = kzalloc(sizeof(char) * (len + 1), GFP_KERNEL);
 	path = kzalloc(sizeof(char) * len, GFP_KERNEL);
 	if (!name || !path) {
 		kfree(name);
 		kfree(path);
-		pr_err("failed to allocate base block device name or path\n");
+		pr_err("failed to allocate name or path\n");
 		return -ENOMEM;
 	}
 
@@ -68,7 +68,7 @@ static int base_name_and_path_set(const char *arg, const struct kernel_param *kp
 
 	base_handle->name = name;
 	base_handle->path = path;
-
+	
 	return 0;
 }
 
@@ -81,8 +81,8 @@ static int base_name_get(char *buf, const struct kernel_param *kp)
 		return -EINVAL;
 	}
 
-	len = strlen(base_handle->path);
-	strcpy(buf, base_handle->path);
+	len = strlen(base_handle->name);
+	strcpy(buf, base_handle->name);
 
 	return len;
 }
@@ -117,7 +117,7 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 
 	base_handle->bdev_file = bdev_file;
 
-	pr_warn("%s:open", base_handle->path);
+	pr_warn("%s: open", base_handle->path);
 
 	return 0;
 }

--- a/driver.c
+++ b/driver.c
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * A block device driver module by: Daniel Vlasenco
+ */
+
+#include <linux/blkdev.h>
+#include <linux/module.h>
+
+#define THIS_DEVICE_NAME "sdmy"
+#define THIS_DEVICE_PATH "/dev/sdmy"
+
+static struct block_device_handle {
+	char *name;
+	char *path;
+};
+
+static struct block_device_handle *base_handle;
+
+static int __init blkdevm_init(void)
+{
+	pr_info("blkdev module init\n");
+
+	return 0;
+}
+
+static void __exit blkdevm_exit(void)
+{
+	if (base_handle) {
+		kfree(base_handle->name);
+		kfree(base_handle->path);
+	}
+	kfree(base_handle);
+
+	pr_info("blkdev module exit\n");
+}
+
+static int base_name_and_path_set(const char *arg, const struct kernel_param *kp)
+{
+	int len;
+	char *name;
+	char *path;
+
+	if (!base_handle) {
+		base_handle = kzalloc(sizeof(*base_handle), GFP_KERNEL);
+		if (!base_handle)
+			return -ENOMEM;
+	}
+	len = strlen(arg);
+
+	name = kzalloc(sizeof(char) * (len + 1), GFP_KERNEL);
+	path = kzalloc(sizeof(char) * len, GFP_KERNEL);
+	if (!name || !path) {
+		kfree(name);
+		kfree(path);
+		pr_err("failed to allocate base block device name or path\n");
+		return -ENOMEM;
+	}
+
+	strncpy(name, arg, len);
+	strncpy(path, arg, len - 1);
+
+	base_handle->name = name;
+	base_handle->path = path;
+
+	return 0;
+}
+
+static int base_name_get(char *buf, const struct kernel_param *kp)
+{
+	ssize_t len;
+
+	if (!base_handle || !base_handle->name) {
+		pr_err("base device name was not set\n");
+		return -EINVAL;
+	}
+
+	len = strlen(base_handle->name);
+	strcpy(buf, base_handle->name);
+
+	return len;
+}
+
+static const struct kernel_param_ops base_ops = {
+	.set = base_name_and_path_set,
+	.get = base_name_get,
+};
+
+MODULE_PARM_DESC(base, "Base block device name");
+module_param_cb(base, &base_ops, NULL, S_IRUGO | S_IWUSR);
+
+module_init(blkdevm_init);
+module_exit(blkdevm_exit);
+
+MODULE_AUTHOR("Vlasenko Daniil <vlasenko.daniil26@gmail.com>");
+MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("Block device driver module");

--- a/driver.c
+++ b/driver.c
@@ -156,7 +156,6 @@ static const struct kernel_param_ops open_ops = {
 static struct gendisk *init_disk(sector_t capacity)
 {
 	struct gendisk *disk;
-	int err;
 
 	disk = blk_alloc_disk(NULL, NUMA_NO_NODE);
 	if (IS_ERR(disk)) {
@@ -170,14 +169,7 @@ static struct gendisk *init_disk(sector_t capacity)
 	strcpy(disk->disk_name, THIS_DEVICE_NAME);
 	disk->fops = &sdmy_fops;
 
-	err = add_disk(disk);
-	if (err) {
-		pr_err("failed to add disk\n");
-		put_disk(disk);
-		return ERR_PTR(err);
-	}
-
-	pr_warn("requested capacity: %llu", capacity);
+	pr_warn("requested capacity: %llu\n", capacity);
 	set_capacity(disk, capacity);
 	pr_warn("actual capacity: %llu\n", get_capacity(disk));
 
@@ -199,6 +191,8 @@ static int close_base(const char *arg, const struct kernel_param *kp)
 	put_disk(base_handle->assoc_disk);
 	base_handle->bdev_file = NULL;
 	base_handle->assoc_disk = NULL;
+
+	pr_warn("%s: close\n", base_handle->path);
 
 	return 0;
 }


### PR DESCRIPTION
Add three module parameters: `base`, `open`, `close`.

`base`: has getter and setter, it stores the name (path in system) of existing block device where driver will redirect operations. Setter doesn't validate name, it is validated by open.

`open`: has setter, tries to open base block device that is stored in base.
If such block device exists, tries to initialize virtual disk with the same capacity and associates it with this block device.
Disk doesn't appear in system yet.

`close`: closes the opened device, clears all resources claimed by open.