### PR TITLE
Add function to redirect bio to base block device

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -146,7 +146,7 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 	base_handle->bh = bh;
 	base_handle->assoc_disk = new_disk;
 
-	pr_info("opened device '%s' and created disk '%s' based on it\n",
+	pr_warn("opened device '%s' and created disk '%s' based on it\n",
 			base_handle->path, new_disk->disk_name);
 
 	return 0;
@@ -208,7 +208,7 @@ static int close_base(const char *arg, const struct kernel_param *kp)
 	put_disk(base_handle->assoc_disk);
 	base_handle->assoc_disk = NULL;
 
-	pr_info("closed device and destroyed disk successfuly\n");
+	pr_warn("closed device and destroyed disk successfuly\n");
 
 	return 0;
 }

--- a/driver.c
+++ b/driver.c
@@ -10,6 +10,7 @@
 #define THIS_DEVICE_PATH "/dev/sdmy"
 
 static struct gendisk *init_disk(sector_t capacity);
+void sdmy_submit_bio(struct bio *bio);
 static const struct block_device_operations sdmy_fops;
 
 static struct block_device_handle {
@@ -136,7 +137,7 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 	base_disk = base_dev->bd_disk;
 	base_disk_cap = get_capacity(base_disk);
 	new_disk = init_disk(base_disk_cap);
-	if (IS_ERR(new_disk)) {
+	if (IS_ERR_OR_NULL(new_disk)) {
 		bdev_release(bh);
 		return PTR_ERR(new_disk);
 	}
@@ -161,7 +162,7 @@ static struct gendisk *init_disk(sector_t capacity)
 	struct gendisk *disk;
 
 	disk = blk_alloc_disk(NUMA_NO_NODE);
-	if (!disk) {
+	if (IS_ERR_OR_NULL(disk)) {
 		pr_err("failed to allocate disk\n");
 		return disk;
 	}

--- a/driver.c
+++ b/driver.c
@@ -221,6 +221,7 @@ static void sdmy_submit_bio(struct bio *bio)
 	new_bio = bio_alloc_clone(base_dev, bio, GFP_KERNEL, bio_pool);
 	if (!new_bio) {
 		pr_err("failed to allocate new bio based on incoming bio\n");
+		bio_io_error(bio);
 		return;
 	}
 

--- a/driver.c
+++ b/driver.c
@@ -10,7 +10,7 @@
 #define THIS_DEVICE_PATH "/dev/sdmy"
 
 static struct gendisk *init_disk(sector_t capacity);
-void sdmy_submit_bio(struct bio *bio);
+static void sdmy_submit_bio(struct bio *bio);
 static const struct block_device_operations sdmy_fops;
 
 static struct block_device_handle {
@@ -21,15 +21,31 @@ static struct block_device_handle {
 };
 
 static struct block_device_handle *base_handle;
+static struct bio_set *bio_pool;
 static int major;
 
 static int __init blkdevm_init(void)
 {
+	int err;
+
 	major = register_blkdev(0, THIS_DEVICE_NAME);
 	if (major < 0) {
 		pr_err("failed to obtain major\n");
 		return major;
 	}
+	bio_pool = kzalloc(sizeof(*bio_pool), GFP_KERNEL);
+	if (!bio_pool) {
+		pr_err("failed to allocate bioset\n");
+		return -ENOMEM;
+	}
+	err = bioset_init(bio_pool, BIO_POOL_SIZE, 0, BIOSET_NEED_BVECS);
+	if (err) {
+		pr_err("failed to initialize bioset\n");
+		bioset_exit(bio_pool);
+		kfree(bio_pool);
+		return err;
+	}
+
 	pr_warn("blkdev module init\n");
 
 	return 0;
@@ -42,13 +58,15 @@ static void __exit blkdevm_exit(void)
 		kfree(base_handle->path);
 	}
 	if (base_handle && base_handle->assoc_disk) {
+		del_gendisk(base_handle->assoc_disk);
 		put_disk(base_handle->assoc_disk);
 	}
 	if (base_handle && base_handle->bh) {
 		bdev_release(base_handle->bh);
 	}
 	kfree(base_handle);
-
+	bioset_exit(bio_pool);
+	kfree(bio_pool);
 	unregister_blkdev(major, THIS_DEVICE_NAME);
 
 	pr_warn("blkdev module exit\n");
@@ -109,13 +127,12 @@ static const struct kernel_param_ops base_ops = {
 	.get = base_name_get,
 };
 
-static int open_base(const char *arg, const struct kernel_param *kp)
+static int open_base_and_create_disk(const char *arg, const struct kernel_param *kp)
 {
 	struct bdev_handle *bh;
-	struct block_device *base_dev;
-	struct gendisk *base_disk;
 	sector_t base_disk_cap;
 	struct gendisk *new_disk;
+	int err;
 
 	if (!base_handle || !base_handle->path) {
 		pr_err("nothing to open\n");
@@ -133,18 +150,26 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 		return PTR_ERR(bh);
 	}
 
-	base_dev = bh->bdev;
-	base_disk = base_dev->bd_disk;
-	base_disk_cap = get_capacity(base_disk);
+	base_disk_cap = get_capacity(bh->bdev->bd_disk);
 	new_disk = init_disk(base_disk_cap);
 	if (IS_ERR_OR_NULL(new_disk)) {
+		pr_err("failed to initialize disk\n");
 		bdev_release(bh);
 		return PTR_ERR(new_disk);
 	}
 	new_disk->private_data = base_handle;
-
 	base_handle->bh = bh;
 	base_handle->assoc_disk = new_disk;
+
+	err = add_disk(new_disk);
+	if (err) {
+		pr_err("failed to add disk after initialization\n");
+		bdev_release(bh);
+		put_disk(new_disk);
+		base_handle->bh = NULL;
+		base_handle->assoc_disk = NULL;
+		return err;
+	}
 
 	pr_warn("opened device '%s' and created disk '%s' based on it\n",
 			base_handle->path, new_disk->disk_name);
@@ -153,7 +178,7 @@ static int open_base(const char *arg, const struct kernel_param *kp)
 }
 
 static const struct kernel_param_ops open_ops = {
-	.set = open_base,
+	.set = open_base_and_create_disk,
 	.get = NULL,
 };
 
@@ -180,9 +205,37 @@ static struct gendisk *init_disk(sector_t capacity)
 	return disk;
 }
 
+static void sdmy_submit_bio(struct bio *bio)
+{
+	struct bio *new_bio;
+	struct block_device *base_dev;
+
+	pr_warn("received bio\n");
+
+	// when we get here, we should have device opened and disk created
+	BUG_ON(!base_handle);
+	BUG_ON(!base_handle->bh);
+	BUG_ON(!base_handle->assoc_disk);
+
+	base_dev = base_handle->bh->bdev;
+	new_bio = bio_alloc_clone(base_dev, bio, GFP_KERNEL, bio_pool);
+	if (!new_bio) {
+		pr_err("failed to allocate new bio based on incoming bio\n");
+		return;
+	}
+
+	pr_warn("bio cloned successfully\n");
+
+	bio_chain(new_bio, bio);
+	submit_bio(new_bio);
+	bio_endio(bio);
+
+	pr_warn("bio redirected successfully\n");
+}
+
 static const struct block_device_operations sdmy_fops = {
 	.owner = THIS_MODULE,
-	// .submit_bio = sdmy_submit_bio,
+	.submit_bio = sdmy_submit_bio,
 };
 
 static int close_base(const char *arg, const struct kernel_param *kp)
@@ -208,7 +261,7 @@ static int close_base(const char *arg, const struct kernel_param *kp)
 	put_disk(base_handle->assoc_disk);
 	base_handle->assoc_disk = NULL;
 
-	pr_warn("closed device and destroyed disk successfuly\n");
+	pr_warn("closed device and destroyed disk successfully\n");
 
 	return 0;
 }


### PR DESCRIPTION
Add `sdmy_submit_bio` function, which redirects all incoming bios' to base block device.

Add `add_disk` function call to base opening function, it now works because bio can be submitted. 

Fix bug with disk not disappearing from system after close function call.

Replace `pr_info` with `pr_warn` for consistency.