### PR TITLE
Change module and module-related names

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -9,6 +9,6 @@ ccflags-y :=	-Wall					\
 		-Werror=format-security			\
 		-Werror=implicit-function-declaration
 
-blkdev-y := driver.o
+blkm-y := driver.o
 
-obj-m := blkdev.o
+obj-m := blkm.o

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 KVER ?= $(shell uname -r)
-LK_BUILD_DIR ?= /lib/modules/$(KVER)/build
-LK_SRC_DIR_RHEL := /usr/src/kernels/$(KVER)
+LK_SRC_DIR := /usr/src/kernels/$(KVER)
 
 all: build
 
 build:
-	$(MAKE) -j -C $(LK_SRC_DIR_RHEL) M=$(PWD) modules
+	$(MAKE) -j -C $(LK_SRC_DIR) M=$(PWD) modules
 
 clean:
-	$(MAKE) -j -C $(LK_SRC_DIR_RHEL) M=$(PWD) clean
+	$(MAKE) -j -C $(LK_SRC_DIR) M=$(PWD) clean

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# blkdevm
+# blkm
 Block device driver module for Linux kernel.


### PR DESCRIPTION
According to our instructor, some module-specific structures and functions should have a short prefix of their module, `blkdevm` was too long.

Moreover, some of the objects had `sdmy` (like sdX, but my) in them, so I changed everything that had one of these two to have common `blkm`.

I also updated README and Kbuild accordingly.

Deleted an extra variable from Makefile and shortened another variable's name.