### PR TITLE
Add details why build can fail to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Kernel source code is usually located in `/usr/src/` or in `/usr/src/kernels/`. 
 ## Build
 
 From repo's directory, run `make`. If you see an error, it can mean that you need to open Makefile and correct your kernel's location (or name).
+It can also mean that your kernel version does not support this driver.
 
 To insert module into running kernel, run `insmod blkm.ko`.
 


### PR DESCRIPTION
Some may try to build this driver module on a very different kernel from which it was created for, so I added a detail to clarify this behaviour.