### PR TITLE
Implement virtual to real block device sectors mapping (log structured)

### DIFF
--- a/blkm.h
+++ b/blkm.h
@@ -1,7 +1,18 @@
 #include <linux/blkdev.h>
+#include <linux/limits.h>
 
-struct skiplist_node;
-struct skiplist;
+struct skiplist_node {
+	struct skiplist_node *next;
+	struct skiplist_node *lower;
+	sector_t key;
+	sector_t data;
+};
+
+struct skiplist {
+	struct skiplist_node *head;
+	int head_lvl;
+	int max_lvl;
+};
 
 struct skiplist *skiplist_init(void);
 struct skiplist_node *skiplist_find_node(sector_t key, struct skiplist *sl);

--- a/blkm.h
+++ b/blkm.h
@@ -19,3 +19,4 @@ struct skiplist_node *skiplist_find_node(sector_t key, struct skiplist *sl);
 struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 					struct skiplist *sl);
 void skiplist_free(struct skiplist *sl);
+void skiplist_print(struct skiplist *sl);

--- a/blkm.h
+++ b/blkm.h
@@ -5,5 +5,6 @@ struct skiplist;
 
 struct skiplist *skiplist_init(void);
 struct skiplist_node *skiplist_find_node(sector_t key, struct skiplist *sl);
-int skiplist_add(sector_t key, sector_t data, struct skiplist *sl);
+struct skiplist_node *skiplist_add(sector_t key, sector_t data,
+					struct skiplist *sl);
 void skiplist_free(struct skiplist *sl);

--- a/blkm.h
+++ b/blkm.h
@@ -16,7 +16,7 @@ struct skiplist {
 
 struct skiplist *skiplist_init(void);
 struct skiplist_node *skiplist_find_node(sector_t key, struct skiplist *sl);
-struct skiplist_node *skiplist_add(sector_t key, sector_t data,
-					struct skiplist *sl);
 void skiplist_free(struct skiplist *sl);
 void skiplist_print(struct skiplist *sl);
+struct skiplist_node *skiplist_add(sector_t key, sector_t data,
+					struct skiplist *sl);

--- a/driver.c
+++ b/driver.c
@@ -54,7 +54,18 @@ static int __init blkm_init(void)
 		err = -ENOMEM;
 		goto init_fail;
 	}
+	pr_warn("skiplist has address %p\n", skiplist);
+	pr_warn("skiplist head has address %p\n", skiplist->head);
+	pr_warn("head level = %d, max level = %d\n",
+		skiplist->head_lvl, skiplist->max_lvl);
 
+	skiplist_print(skiplist);
+	if (!skiplist_add(0, 0, skiplist)) {
+		pr_warn("failed to add partition table mapping to skiplist\n");
+		err = -ENOMEM;
+		goto init_fail;
+	}
+	pr_warn("partition table mapped\n");
 	pr_warn("blkdev module init\n");
 	return 0;
 
@@ -261,7 +272,7 @@ static int redirect_write(struct bio *bio)
 			orig_address, redir_address);
 		return PTR_ERR(node);
 	}
-
+	skiplist_print(skiplist);
 	if (redir_address == node->data) {
 		pr_warn("successful write: address %llu is already mapped to %llu\n",
 			orig_address, redir_address);

--- a/driver.c
+++ b/driver.c
@@ -218,7 +218,7 @@ static struct gendisk *init_disk(sector_t capacity)
 	return disk;
 }
 
-int redirect_read(struct bio *bio)
+static int redirect_read(struct bio *bio)
 {
 	struct skiplist_node *node;
 	sector_t orig_address;

--- a/driver.c
+++ b/driver.c
@@ -54,6 +54,7 @@ static int __init blkm_init(void)
 		err = -ENOMEM;
 		goto init_fail;
 	}
+	pr_warn("blkdev module init\n");
 	return 0;
 
 init_fail:

--- a/skiplist.c
+++ b/skiplist.c
@@ -94,8 +94,8 @@ alloc_fail:
 	return NULL;
 }
 
-static int get_prev_nodes(sector_t key, struct skiplist *sl,
-			struct skiplist_node *buf, int lvl)
+static void get_prev_nodes(sector_t key, struct skiplist *sl,
+			struct skiplist_node **buf, int lvl)
 {
 	struct skiplist_node *curr;
 	int lvls_passed;

--- a/skiplist.c
+++ b/skiplist.c
@@ -4,26 +4,12 @@
  */
 
 #include "blkm.h"
-#include <vdso/limits.h>
 
 #define HEAD_KEY ((sector_t)0)
-#define HEAD_DATA ((sector_t)ULONG_MAX)
-#define TAIL_KEY ((sector_t)ULONG_MAX)
+#define HEAD_DATA ((sector_t)U64_MAX)
+#define TAIL_KEY ((sector_t)U64_MAX)
 #define TAIL_DATA ((sector_t)0)
 #define MAX_LVL 20
-
-struct skiplist_node {
-	struct skiplist_node *next;
-	struct skiplist_node *lower;
-	sector_t key;
-	sector_t data;
-};
-
-struct skiplist {
-	struct skiplist_node *head;
-	int head_lvl;
-	int max_lvl;
-};
 
 static void free_node_full(struct skiplist_node *node)
 {

--- a/skiplist.c
+++ b/skiplist.c
@@ -180,14 +180,6 @@ static int get_random_lvl(int max) {
 	return lvl;
 }
 
-static void replace_data(struct skiplist_node *node, sector_t data)
-{
-	while (node) {
-		node->data = data;
-		node = node->lower;
-	}
-}
-
 struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 					struct skiplist *sl)
 {

--- a/skiplist.c
+++ b/skiplist.c
@@ -88,11 +88,12 @@ static void get_prev_nodes(sector_t key, struct skiplist *sl,
 
 	lvls_passed = 0;
 	curr = sl->head;
-	while (curr && lvls_passed < lvl) {
+	while (curr && lvls_passed <= lvl) {
 		if (curr->next->key < key || curr->data != HEAD_DATA) {
 			curr = curr->next;
 		} else {
-			buf[lvl-lvls_passed-1] = curr;
+			buf[lvl-lvls_passed] = curr;
+			pr_warn("buf[%d] is %p\n", lvl-lvls_passed, curr);
 			++lvls_passed;
 			curr = curr->lower;
 		}

--- a/skiplist.c
+++ b/skiplist.c
@@ -44,7 +44,7 @@ static struct skiplist_node *create_node_tall(sector_t key, sector_t data,
 	return curr;
 
 alloc_fail:
-	free_node_full(curr);
+	free_node_full(last);
 
 	return NULL;
 }
@@ -228,6 +228,7 @@ struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 	pr_warn("curr lvl = %d\n", sl->head_lvl);
 
 	get_prev_nodes(key, sl, prev, lvl);
+
 	for (i = 0; i <= lvl; ++i) {
 		new = create_node(key, data);
 		if (!new) {

--- a/skiplist.c
+++ b/skiplist.c
@@ -282,3 +282,25 @@ void skiplist_free(struct skiplist *sl)
 
 	kfree(sl);
 }
+
+void skiplist_print(struct skiplist *sl) {
+	struct skiplist_node *curr;
+	struct skiplist_node *head;
+
+	head = sl->head;
+	while (head) {
+		curr = head;
+		while (curr) {
+			if (curr->key == HEAD_KEY && curr->data == HEAD_DATA)
+				printk("head->");
+			else if (curr->key == TAIL_KEY && curr->data == TAIL_DATA)
+				printk("tail->");
+			else
+				printk("(%llu-%llu)->", curr->key, curr->data);
+
+			curr = curr->next;
+		}
+		printk("\n");
+		head = head->lower;
+	}
+}

--- a/skiplist.c
+++ b/skiplist.c
@@ -299,11 +299,11 @@ void skiplist_print(struct skiplist *sl) {
 		curr = head;
 		while (curr) {
 			if (curr->key == HEAD_KEY && curr->data == HEAD_DATA)
-				printk("head->");
+				printk(KERN_CONT "head->");
 			else if (curr->key == TAIL_KEY && curr->data == TAIL_DATA)
-				printk("tail->");
+				printk(KERN_CONT "tail->");
 			else
-				printk("(%llu-%llu)->", curr->key, curr->data);
+				printk(KERN_CONT "(%llu-%llu)->", curr->key, curr->data);
 
 			curr = curr->next;
 		}


### PR DESCRIPTION
The mapping is done by storing virtual address-real address (key-value) pairs inside the skiplist.

Debugged skiplist for this mapping to work.

When the driver receives bio, its' destination address is changed to be first free base block's device sector.
They start from 0.

If bio's operation is write, then above mentioned mapping is added to skiplist. Then, if someone wishes to read the same address, the mapping will be done again.

If bio's operation is read, then driver tries to search skiplist to find where to map this address. If it does not find appropriate address, it attempts to add new mapping, then read.

Move skiplist.c structs to header to be accessible from driver.c.

Refactored error handling using gotos. Refactored names to be more clear.

Add many debug messages, which will be removed in the future, and also add function to print skiplist (for debug).
 