### PR TITLE
Refactor skiplist.c for more readability

### DIFF
--- a/skiplist.c
+++ b/skiplist.c
@@ -198,13 +198,15 @@ static void get_prev_nodes(sector_t key, struct skiplist *sl,
 	}
 }
 
-static int insert_after_prev(sector_t key, sector_t data,
-			struct skiplist_node **prev, int lvl)
+static int skiplist_insert_at_lvl(sector_t key, sector_t data,
+				struct skiplist *sl, int lvl)
 {
+	struct skiplist_node *prev[sl->max_lvl+1];
 	struct skiplist_node *new;
 	struct skiplist_node *temp;
 	int i;
 
+	get_prev_nodes(key, sl, prev, lvl);
 	temp = NULL;
 	for (i = 0; i <= lvl; ++i) {
 		new = create_node(key, data);
@@ -230,7 +232,6 @@ fail:
 struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 					struct skiplist *sl)
 {
-	struct skiplist_node *prev[sl->max_lvl+1];
 	struct skiplist_node *old;
 	struct skiplist_node *new;
 	int lvl;
@@ -247,8 +248,7 @@ struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 	if (err)
 		goto fail;
 
-	get_prev_nodes(key, sl, prev, lvl);
-	err = insert_after_prev(key, data, prev, lvl);
+	err = skiplist_insert_at_lvl(key, data, sl, lvl);
 	if (err)
 		goto fail;
 

--- a/skiplist.c
+++ b/skiplist.c
@@ -169,14 +169,6 @@ static int get_random_lvl(int max) {
 	return lvl;
 }
 
-static void replace_node_data(struct skiplist_node *node, sector_t new_data)
-{
-	while (node) {
-		node->data = new_data;
-		node = node->lower;
-	}
-}
-
 static void get_prev_nodes(sector_t key, struct skiplist *sl,
 			struct skiplist_node **buf, int lvl)
 {
@@ -238,10 +230,8 @@ struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 	int err;
 
 	old = skiplist_find_node(key, sl);
-	if (old) {
-		replace_node_data(old, data);
+	aif (old)
 		return old;
-	}
 
 	lvl = get_random_lvl(sl->max_lvl);
 	err = move_up_if_lvl_nex(sl, lvl);

--- a/skiplist.c
+++ b/skiplist.c
@@ -80,40 +80,6 @@ alloc_fail:
 	return NULL;
 }
 
-static void get_prev_nodes(sector_t key, struct skiplist *sl,
-			struct skiplist_node **buf, int lvl)
-{
-	struct skiplist_node *curr;
-	int curr_lvl;
-
-	curr = sl->head;
-	curr_lvl = sl->head_lvl;
-	pr_warn("need to get prev nodes for key %llu\n", key);
-
-	while (curr && curr_lvl >= 0) {
-		pr_warn("curr key %llu, next key %llu, curr lvl %d, max pred lvl %d\n",
-			curr->key, curr->next->key, curr_lvl, lvl);
-		if (curr->next->key < key) {
-			pr_warn("moving forward, next is %p\n", curr->next);
-			curr = curr->next;
-		} else {
-			if (curr_lvl <= lvl) {
-				buf[curr_lvl] = curr;
-				pr_warn("buf[%d] is %p with key %llu\n",
-					curr_lvl, buf[curr_lvl], buf[curr_lvl]->key);
-			}
-			pr_warn("moving down, lower is %p\n", curr->lower);
-			--curr_lvl;
-			curr = curr->lower;
-		}
-	}
-
-	for (int i = 0; i <= lvl; ++i) {
-		pr_warn("buf[%d] is %p with key %llu\n",
-			i, buf[i], buf[i]->key);
-	}
-}
-
 struct skiplist_node *skiplist_find_node(sector_t key, struct skiplist *sl)
 {
 	struct skiplist_node *curr = sl->head;
@@ -203,20 +169,78 @@ static int get_random_lvl(int max) {
 	return lvl;
 }
 
+static void replace_node_data(struct skiplist_node *node, sector_t new_data)
+{
+	while (node) {
+		node->data = new_data;
+		node = node->lower;
+	}
+}
+
+static void get_prev_nodes(sector_t key, struct skiplist *sl,
+			struct skiplist_node **buf, int lvl)
+{
+	struct skiplist_node *curr;
+	int curr_lvl;
+
+	curr = sl->head;
+	curr_lvl = sl->head_lvl;
+	while (curr && curr_lvl >= 0) {
+		if (curr->next->key < key) {
+			curr = curr->next;
+		} else {
+			if (curr_lvl <= lvl) {
+				buf[curr_lvl] = curr;
+			}
+			--curr_lvl;
+			curr = curr->lower;
+		}
+	}
+}
+
+static int insert_after_prev(sector_t key, sector_t data,
+			struct skiplist_node **prev, int lvl)
+{
+	struct skiplist_node *new;
+	struct skiplist_node *temp;
+	int i;
+
+	temp = NULL;
+	for (i = 0; i <= lvl; ++i) {
+		new = create_node(key, data);
+		if (!new)
+			goto fail;
+		new->next = prev[i]->next;
+		new->lower = temp;
+		prev[i]->next = new;
+		temp = new;
+	}
+
+	return 0;
+fail:
+	for (i = i - 1; i >= 0; --i) {
+		new = prev[i]->next;
+		prev[i]->next = new->next;
+		kfree(new);
+	}
+
+	return -ENOMEM;
+}
+
 struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 					struct skiplist *sl)
 {
 	struct skiplist_node *prev[sl->max_lvl+1];
 	struct skiplist_node *old;
 	struct skiplist_node *new;
-	struct skiplist_node *temp;
 	int lvl;
 	int err;
-	int i;
 
 	old = skiplist_find_node(key, sl);
-	if (old)
+	if (old) {
+		replace_node_data(old, data);
 		return old;
+	}
 
 	lvl = get_random_lvl(sl->max_lvl);
 	err = move_up_if_lvl_nex(sl, lvl);
@@ -224,35 +248,14 @@ struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 		goto fail;
 
 	get_prev_nodes(key, sl, prev, lvl);
+	err = insert_after_prev(key, data, prev, lvl);
+	if (err)
+		goto fail;
 
-	temp = NULL;
-	for (i = 0; i <= lvl; ++i) {
-		new = create_node(key, data);
-		if (!new) {
-			err = -ENOMEM;
-			goto alloc_fail;
-		}
-		pr_warn("created node %p with key %llu and data %llu\n",
-			new, new->key, new->data);
-		if (temp) {
-			new->lower = temp;
-			pr_warn("connected node %p with key %llu from lvl %d to node %p with key %llu from lvl %d\n",
-				new, new->key, i, temp, temp->key, i-1);
-		}
-		new->next = prev[i]->next ;
-		prev[i]->next = new;
-		temp = new;
-	}
 	skiplist_print(sl);
 
 	return new;
 
-alloc_fail:
-	for (i = i - 1; i >= 0; --i) {
-		new = prev[i]->next;
-		prev[i]->next = new->next;
-		kfree(new);
-	}
 fail:
 	return ERR_PTR(err);
 }


### PR DESCRIPTION
Added function to replace data by key.  Thought a little and removed it, because it is useless for now.

Moved insertion logic out of skiplist_add, so code is more readable and convenient. Also moved get_prev_nodes out of it, because it is really no need for two functions to share buffer within third function.

Moved get_prev_nodes code closer to the place it is used in.