### PR TITLE
Fix warnings and correct include files

### DIFF
--- a/blkm.h
+++ b/blkm.h
@@ -1,5 +1,4 @@
-#include <linux/blkdev.h>
-#include <linux/limits.h>
+#include <linux/module.h>
 
 struct skiplist_node {
 	struct skiplist_node *next;

--- a/driver.c
+++ b/driver.c
@@ -18,9 +18,8 @@ static struct blkm_dev {
 	struct bdev_handle *bh;
 	struct gendisk *assoc_disk;
 	char *path;
-};
+} *base_handle;
 
-static struct blkm_dev *base_handle;
 static struct bio_set *bio_pool;
 static int major;
 

--- a/driver.c
+++ b/driver.c
@@ -4,7 +4,7 @@
  */
 
 #include "blkm.h"
-#include <linux/module.h>
+#include <linux/blkdev.h>
 
 #define THIS_DEVICE_NAME "sdblk"
 #define THIS_DEVICE_PATH "/dev/sdblk"

--- a/skiplist.c
+++ b/skiplist.c
@@ -189,7 +189,7 @@ static void get_prev_nodes(sector_t key, struct skiplist *sl,
 static int skiplist_insert_at_lvl(sector_t key, sector_t data,
 				struct skiplist *sl, int lvl)
 {
-	struct skiplist_node *prev[sl->max_lvl+1];
+	struct skiplist_node *prev[MAX_LVL+1];
 	struct skiplist_node *new;
 	struct skiplist_node *temp;
 	int i;


### PR DESCRIPTION
Replaced variable sized array with compile-time constant size array (could've done earlier, but didn't pay attention).

Removed useless storage class specifier (a struct, which is used as a type only once, when declaring a pointer to it).

Corrected includes, so we include less unneeded files for now.