### PR TITLE
Add ci build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,16 @@
+name: Build kernel 6.8
+
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+
+jobs: 
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: build
+        run: |
+          sudo apt install build-essential linux-headers-6.8.0-1010-azure
+          make build

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 KVER ?= $(shell uname -r)
-LK_SRC_DIR := /usr/src/kernels/$(KVER)
+OS := $(shell lsb_release -si)
+
+LK_SRC_DIR_FED := /usr/src/kernels/$(KVER)
+LK_SRC_DIR_ELSE := /usr/src/$(KVER)
+
+ifeq ($(OS),Fedora)
+	LK_SRC_DIR := $(LK_SRC_DIR_FED)
+else
+	LK_SRC_DIR := $(LK_SRC_DIR_ELSE)
+endif
 
 all: build
 

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,12 @@ KVER ?= $(shell uname -r)
 OS := $(shell lsb_release -si)
 
 LK_SRC_DIR_FED := /usr/src/kernels/$(KVER)
-LK_SRC_DIR_ELSE := /usr/src/$(KVER)
+LK_SRC_DIR_UB := /usr/src/linux-headers-$(KVER)
 
 ifeq ($(OS),Fedora)
 	LK_SRC_DIR := $(LK_SRC_DIR_FED)
 else
-	LK_SRC_DIR := $(LK_SRC_DIR_ELSE)
+	LK_SRC_DIR := $(LK_SRC_DIR_UB)
 endif
 
 all: build


### PR DESCRIPTION
Add ci workflow running on ubuntu 24.04 for building kernel module.

Modify Makefile to determine whether OS is Ubuntu or Fedora (which are my host and guest OS'es).