### PR TITLE
Remove undeclared and unused variables

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -357,9 +357,6 @@ static int close_base(const char *arg, const struct kernel_param *kp)
 		pr_err("disk wasn't allocated, cannot close\n");
 		return -EINVAL;
 	}
-	disk_name = base_handle->assoc_disk->disk_name;
-	pr_warn("closing device '%s' and destroying disk '%s' based on it\n",
-			base_handle->path, disk_name);
 
 	skiplist_free(skiplist);
 	skiplist = NULL;

--- a/skiplist.c
+++ b/skiplist.c
@@ -220,7 +220,6 @@ fail:
 struct skiplist_node *skiplist_add(sector_t key, sector_t data,
 					struct skiplist *sl)
 {
-	struct skiplist_node *prev[MAX_LVL+1];
 	struct skiplist_node *old;
 	struct skiplist_node *new;
 	int lvl;


### PR DESCRIPTION
I didn't notice that I had left some undeclared and unused variables after rebase, so I've removed it now. 