### PR TITLE
Make build run only on push/pr to main

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,10 +2,13 @@ name: Build kernel 6.8
 
 on:
   push:
+    branches:
+      'main'
   workflow_dispatch:
   pull_request:
+      'main'
 
-jobs: 
+jobs:
   build:
     runs-on: ubuntu-24.04
     steps:


### PR DESCRIPTION
Made build workflow to run only when push or pull request is to main.

And removed extra whitespace.